### PR TITLE
Fix indent in diff log

### DIFF
--- a/caerbannog/logging/context.py
+++ b/caerbannog/logging/context.py
@@ -40,6 +40,9 @@ class LogContext:
     def detail_green(self, msg):
         print(f"    {self._indent()}{FG_GREEN}{msg}{FG_RESET}", file=sys.stderr)
 
+    def detail_cyan(self, msg):
+        print(f"    {self._indent()}{FG_CYAN}{msg}{FG_RESET}", file=sys.stderr)
+
     def _indent(self) -> str:
         return "  " * self._depth
 

--- a/caerbannog/operations/operation.py
+++ b/caerbannog/operations/operation.py
@@ -236,12 +236,15 @@ class Change:
                     log.detail_green(detail)
                 elif diff_type == DiffType.REMOVE:
                     log.detail_red(detail)
+                elif diff_type == DiffType.HEADER:
+                    log.detail_cyan(detail)
 
 
 class DiffType(Enum):
     NEUTRAL = 0
     ADD = 1
     REMOVE = 2
+    HEADER = 3
 
 
 class DiffLine:
@@ -256,6 +259,10 @@ class DiffLine:
     @staticmethod
     def remove(content: str) -> Tuple[DiffType, str]:
         return (DiffType.REMOVE, f"- {content}")
+
+    @staticmethod
+    def header(content: str) -> Tuple[DiffType, str]:
+        return (DiffType.HEADER, content)
 
     @staticmethod
     def detail(content: str) -> Tuple[DiffType, str]:

--- a/caerbannog/operations/subjects/file.py
+++ b/caerbannog/operations/subjects/file.py
@@ -540,12 +540,16 @@ class ContentChanged(Change):
                 if line == trimmed:
                     trimmed = f"{trimmed}^m"
 
-                if line.startswith("-"):
-                    formatted.append(DiffLine.remove(trimmed[1:]))
-                elif line.startswith("+"):
-                    formatted.append(DiffLine.add(trimmed[1:]))
+                if line.startswith("@"):
+                    formatted.append(DiffLine.header(trimmed))
                 else:
-                    formatted.append(DiffLine.neutral(trimmed))
+                    trimmed = trimmed[1:]
+                    if line.startswith("-"):
+                        formatted.append(DiffLine.remove(trimmed))
+                    elif line.startswith("+"):
+                        formatted.append(DiffLine.add(trimmed))
+                    elif line.startswith(" "):
+                        formatted.append(DiffLine.neutral(trimmed))
             return formatted
 
         def count_by_type(difftype: str):


### PR DESCRIPTION
Currently, the leading space in unchanged diff lines is not removed, which leads to the following diff log:
```
[*]     path /home/wf/.zshrc
        ✓ is file
        ✓ has owner: user=wf group=wf
        ⟳ has content
            content changed
              @@ -5,6 +5,7 @@
               # Load colors
               autoload -Uz colors
               colors
            + # test
```

The `# test` line is one space out of position.

This PR also moves the `@@` lines to be aligned with the `+` and `-` directives and colors them cyan, similar to how Git diffs are rendered.