### PR TITLE
Fix elevated command

### DIFF
--- a/caerbannog/commandline/subcommands.py
+++ b/caerbannog/commandline/subcommands.py
@@ -17,8 +17,9 @@ def configure(args: Namespace):
 
         command = [
             "sudo",
-            "env",
+            "--preserve-env",
             "PYTHONDONTWRITEBYTECODE=1",
+            sys.executable,
             *sys.argv,
             "--context",
             serialized,

--- a/caerbannog/operations/subjects/package.py
+++ b/caerbannog/operations/subjects/package.py
@@ -1,7 +1,7 @@
 import subprocess
 from typing import Dict, Set
 
-from caerbannog import context
+from caerbannog import command, context
 from caerbannog.logging import *
 from caerbannog.operations import *
 
@@ -132,7 +132,9 @@ class PacmanPackageIsInstalled(Assertion):
 
         if context.should_modify():
             install = subprocess.run(
-                ["sudo", "pacman", "--sync", "--noconfirm", *missing],
+                command.create_elevated_command(
+                    "pacman", "--sync", "--noconfirm", *missing
+                ),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,


### PR DESCRIPTION
From the commit message:

```
This changes the sudo command to use --preserve-env flag, since sudo
resets the environment by default, so sudo env is essentially a no-op.

We also explicitly use the same executable for the non-elevated
execution, because even with --preserve-env, sudo resets the PATH
variable (among others) as a security measure.

Note that regardless of whether you run a Python script as 'python
script.py' or './script.py', sys.argv[0] will be './script.py', so
adding the executable will never lead to the executable being specified
twice.
```

The Pacman change just removes the explicitly specified `sudo` command in favor of the centralized command elevation function.